### PR TITLE
Remove deprecated `sudo` travis option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 rvm:
   - 2.4.2


### PR DESCRIPTION
According to https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration